### PR TITLE
Fix pickedGrapes count and blip

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -115,6 +115,7 @@ Citizen.CreateThread(function()
 					TriggerEvent("qb-vineyard:client:startVineyard")
 					Citizen.Wait(20000)
 					startVineyard = false
+					pickedGrapes = 0
 				end
 			end
 		end
@@ -158,11 +159,11 @@ function pickgrapes()
 	if success then
 		TriggerServerEvent("qb-vineyard:server:getGrapes")
 		tasking = false
+		DeleteBlip()
 	end
 end
 
 function CreateBlip()
-	DeleteBlip()
 	if tasking then
 		blip = AddBlipForCoord(grapeLocations[random]["x"],grapeLocations[random]["y"],grapeLocations[random]["z"])
 	end


### PR DESCRIPTION
Fix the delete blip after the last grape has been picked, with the current implementation when the last grape is picked the blip does not get removed. 
Additionally reset the pickedGrapes count or else the count can go infinitely after the first config value has been hit, unless this is intentional?

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
Does your code fit the style guidelines? [yes]
Does your PR fit the contribution guidelines? [yes]
